### PR TITLE
Equal axes

### DIFF
--- a/src/ScottPlot.Demo/Customize/Axis.cs
+++ b/src/ScottPlot.Demo/Customize/Axis.cs
@@ -98,6 +98,7 @@ namespace ScottPlot.Demo.Customize
                 // plot the Cartesian data
                 plt.PlotScatter(xs, ys);
                 plt.Title("Scatter Plot of Polar Data");
+                plt.EqualAxis = true;
             }
         }
     }

--- a/src/ScottPlot/Config/Axes.cs
+++ b/src/ScottPlot/Config/Axes.cs
@@ -10,6 +10,7 @@ namespace ScottPlot.Config
     // Axes (the plural of Axis) represents an X and Y axis
     public class Axes
     {
+        public bool equalAxes = false;
         public Axis x = new Axis();
         public Axis y = new Axis();
 

--- a/src/ScottPlot/Plot.cs
+++ b/src/ScottPlot/Plot.cs
@@ -826,6 +826,17 @@ namespace ScottPlot
             return settings.axes.limits;
         }
 
+        public bool EqualAxis
+        {
+            get => settings.axes.equalAxes;
+            set
+            {
+                settings.axes.equalAxes = value;
+                if (value)
+                    settings.AxisAuto();
+            }
+        }
+
         public double[] AxisEqual(bool preserveY = true)
         {
             if (preserveY)

--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -82,6 +82,18 @@ namespace ScottPlot
             }
 
             layout.Update(width, height);
+            if (axes.equalAxes)
+            {
+                var limits = new Config.AxisLimits2D(axes.ToArray());
+
+                double xUnitsPerPixel = limits.xSpan / dataSize.Width;
+                double yUnitsPerPixel = limits.ySpan / dataSize.Height;
+
+                if (yUnitsPerPixel > xUnitsPerPixel)
+                    axes.Zoom(xUnitsPerPixel / yUnitsPerPixel, 1);
+                else
+                    axes.Zoom(1, yUnitsPerPixel / xUnitsPerPixel);
+            }
         }
 
         public void TightenLayout(int padLeft = 15, int padRight = 15, int padBottom = 15, int padTop = 15)
@@ -150,6 +162,13 @@ namespace ScottPlot
             double dY = (double)yPx / yAxisScale;
             double dXFrac = dX / (Math.Abs(dX) + axes.x.span);
             double dYFrac = dY / (Math.Abs(dY) + axes.y.span);
+            if (axes.equalAxes)
+            {
+                double zoomValue = dX + dY; // NE - max zoomIn, SW - max ZoomOut, NW and SE - 0 zoomValue
+                double zoomFrac = zoomValue / (Math.Abs(zoomValue) + axes.x.span);
+                dXFrac = zoomFrac;
+                dYFrac = zoomFrac;
+            }
             axes.Zoom(Math.Pow(10, dXFrac), Math.Pow(10, dYFrac));
         }
 
@@ -172,7 +191,17 @@ namespace ScottPlot
             }
 
             newLimits.MakeRational();
-
+            if (axes.equalAxes)
+            {
+                var xUnitsPerPixel = newLimits.xSpan / (dataSize.Width * (1 - horizontalMargin));
+                var yUnitsPerPixel = newLimits.ySpan / (dataSize.Height * (1 - verticalMargin));
+                axes.Set(newLimits);
+                if (yUnitsPerPixel > xUnitsPerPixel)
+                    axes.Zoom((1 - horizontalMargin) * xUnitsPerPixel / yUnitsPerPixel, 1 - verticalMargin);
+                else
+                    axes.Zoom(1 - horizontalMargin, (1 - verticalMargin) * yUnitsPerPixel / xUnitsPerPixel);
+                return;
+            }
             if (xExpandOnly)
             {
                 oldLimits.ExpandX(newLimits);


### PR DESCRIPTION
Support of equal axes moved to `Plot` level with this PR.
`Plot.EqualAxis` new API property.
By setting this property to `true` axis stay equal in all (?) possible interactions:
- `AutoAxis`
- `Zoom`
- `Resize`

Additionaly set `Plot.EqualAxis = true` for PolarAxis demo.

Previous `AxisEqual` implementation in `UserControls` stay untouched.